### PR TITLE
Enable switching between imperial and metric measurement systems

### DIFF
--- a/altitude_o2_to_altitude.html
+++ b/altitude_o2_to_altitude.html
@@ -8,42 +8,56 @@
       margin: 20px 0;
       text-align: center;
     }
-    .toggle-switch {
-      background: #ddd;
+    .toggle-group {
+      display: inline-flex;
+      border: 2px solid #ddd;
+      border-radius: 6px;
+      overflow: hidden;
+    }
+    .toggle-button {
+      background: #f8f8f8;
       border: none;
-      border-radius: 20px;
       padding: 10px 20px;
       cursor: pointer;
       font-size: 14px;
-      transition: background-color 0.3s;
+      font-weight: 500;
+      transition: all 0.2s;
+      border-right: 1px solid #ddd;
     }
-    .toggle-switch.active {
+    .toggle-button:last-child {
+      border-right: none;
+    }
+    .toggle-button.active {
       background: #007acc;
       color: white;
+    }
+    .toggle-button:hover:not(.active) {
+      background: #e8e8e8;
     }
   </style>
   <script>
     let isMetric = false;
 
-    function toggleUnits() {
-      isMetric = !isMetric;
+    function setUnits(metric) {
+      isMetric = metric;
       localStorage.setItem('unitPreference', isMetric ? 'metric' : 'imperial');
       updateUI();
     }
 
     function updateUI() {
-      const toggle = document.getElementById('unitToggle');
+      const imperialBtn = document.getElementById('imperialBtn');
+      const metricBtn = document.getElementById('metricBtn');
       const elevationLabel = document.getElementById('elevationLabel');
       const elevationInput = document.getElementById('altitude');
       
       if (isMetric) {
-        toggle.textContent = 'Metric (m)';
-        toggle.classList.add('active');
+        imperialBtn.classList.remove('active');
+        metricBtn.classList.add('active');
         elevationLabel.textContent = 'Enter the local site elevation (meters):';
         elevationInput.placeholder = 'Elevation in meters';
       } else {
-        toggle.textContent = 'Imperial (ft)';
-        toggle.classList.remove('active');
+        imperialBtn.classList.add('active');
+        metricBtn.classList.remove('active');
         elevationLabel.textContent = 'Enter the local site elevation (feet):';
         elevationInput.placeholder = 'Elevation in feet';
       }
@@ -119,7 +133,10 @@
   <h1>Altitude‑O₂ Equivalency Calculator</h1>
 
   <div class="unit-toggle">
-    <button id="unitToggle" class="toggle-switch" onclick="toggleUnits()">Imperial (ft)</button>
+    <div class="toggle-group">
+      <button id="imperialBtn" class="toggle-button active" onclick="setUnits(false)">Imperial (ft)</button>
+      <button id="metricBtn" class="toggle-button" onclick="setUnits(true)">Metric (m)</button>
+    </div>
   </div>
 
   <p id="elevationLabel">Enter the local site elevation (feet):</p>

--- a/altitude_to_o2_percentage.html
+++ b/altitude_to_o2_percentage.html
@@ -8,42 +8,56 @@
       margin: 20px 0;
       text-align: center;
     }
-    .toggle-switch {
-      background: #ddd;
+    .toggle-group {
+      display: inline-flex;
+      border: 2px solid #ddd;
+      border-radius: 6px;
+      overflow: hidden;
+    }
+    .toggle-button {
+      background: #f8f8f8;
       border: none;
-      border-radius: 20px;
       padding: 10px 20px;
       cursor: pointer;
       font-size: 14px;
-      transition: background-color 0.3s;
+      font-weight: 500;
+      transition: all 0.2s;
+      border-right: 1px solid #ddd;
     }
-    .toggle-switch.active {
+    .toggle-button:last-child {
+      border-right: none;
+    }
+    .toggle-button.active {
       background: #007acc;
       color: white;
+    }
+    .toggle-button:hover:not(.active) {
+      background: #e8e8e8;
     }
   </style>
   <script>
     let isMetric = false;
 
-    function toggleUnits() {
-      isMetric = !isMetric;
+    function setUnits(metric) {
+      isMetric = metric;
       localStorage.setItem('unitPreference', isMetric ? 'metric' : 'imperial');
       updateUI();
     }
 
     function updateUI() {
-      const toggle = document.getElementById('unitToggle');
+      const imperialBtn = document.getElementById('imperialBtn');
+      const metricBtn = document.getElementById('metricBtn');
       const label = document.getElementById('inputLabel');
       const input = document.getElementById('altitude');
       
       if (isMetric) {
-        toggle.textContent = 'Metric (m)';
-        toggle.classList.add('active');
+        imperialBtn.classList.remove('active');
+        metricBtn.classList.add('active');
         label.textContent = 'Enter the altitude in meters:';
         input.placeholder = 'Altitude in meters';
       } else {
-        toggle.textContent = 'Imperial (ft)';
-        toggle.classList.remove('active');
+        imperialBtn.classList.add('active');
+        metricBtn.classList.remove('active');
         label.textContent = 'Enter the altitude in feet:';
         input.placeholder = 'Altitude in feet';
       }
@@ -96,7 +110,10 @@
   <h1>Altitude to Oxygen Percentage Calculator</h1>
   
   <div class="unit-toggle">
-    <button id="unitToggle" class="toggle-switch" onclick="toggleUnits()">Imperial (ft)</button>
+    <div class="toggle-group">
+      <button id="imperialBtn" class="toggle-button active" onclick="setUnits(false)">Imperial (ft)</button>
+      <button id="metricBtn" class="toggle-button" onclick="setUnits(true)">Metric (m)</button>
+    </div>
   </div>
   
   <p id="inputLabel">Enter the altitude in feet:</p>

--- a/elevation_equiv_to_o2.html
+++ b/elevation_equiv_to_o2.html
@@ -8,46 +8,60 @@
       margin: 20px 0;
       text-align: center;
     }
-    .toggle-switch {
-      background: #ddd;
+    .toggle-group {
+      display: inline-flex;
+      border: 2px solid #ddd;
+      border-radius: 6px;
+      overflow: hidden;
+    }
+    .toggle-button {
+      background: #f8f8f8;
       border: none;
-      border-radius: 20px;
       padding: 10px 20px;
       cursor: pointer;
       font-size: 14px;
-      transition: background-color 0.3s;
+      font-weight: 500;
+      transition: all 0.2s;
+      border-right: 1px solid #ddd;
     }
-    .toggle-switch.active {
+    .toggle-button:last-child {
+      border-right: none;
+    }
+    .toggle-button.active {
       background: #007acc;
       color: white;
+    }
+    .toggle-button:hover:not(.active) {
+      background: #e8e8e8;
     }
   </style>
   <script>
     let isMetric = false;
 
-    function toggleUnits() {
-      isMetric = !isMetric;
+    function setUnits(metric) {
+      isMetric = metric;
       localStorage.setItem('unitPreference', isMetric ? 'metric' : 'imperial');
       updateUI();
     }
 
     function updateUI() {
-      const toggle = document.getElementById('unitToggle');
+      const imperialBtn = document.getElementById('imperialBtn');
+      const metricBtn = document.getElementById('metricBtn');
       const elevationLabel = document.getElementById('elevationLabel');
       const elevationInput = document.getElementById('altitude');
       const equivLabel = document.getElementById('equivLabel');
       const equivInput = document.getElementById('equiv_altitude');
       
       if (isMetric) {
-        toggle.textContent = 'Metric (m)';
-        toggle.classList.add('active');
+        imperialBtn.classList.remove('active');
+        metricBtn.classList.add('active');
         elevationLabel.textContent = 'Enter the local site elevation (meters):';
         elevationInput.placeholder = 'Local elevation in meters';
         equivLabel.textContent = 'Enter the equivalent altitude (meters):';
         equivInput.placeholder = 'Equivalent altitude in meters';
       } else {
-        toggle.textContent = 'Imperial (ft)';
-        toggle.classList.remove('active');
+        imperialBtn.classList.add('active');
+        metricBtn.classList.remove('active');
         elevationLabel.textContent = 'Enter the local site elevation (feet):';
         elevationInput.placeholder = 'Local elevation in feet';
         equivLabel.textContent = 'Enter the equivalent altitude (feet):';
@@ -118,7 +132,10 @@
   <h1>Elevation & Equivalent Altitude to O₂ Calculator</h1>
 
   <div class="unit-toggle">
-    <button id="unitToggle" class="toggle-switch" onclick="toggleUnits()">Imperial (ft)</button>
+    <div class="toggle-group">
+      <button id="imperialBtn" class="toggle-button active" onclick="setUnits(false)">Imperial (ft)</button>
+      <button id="metricBtn" class="toggle-button" onclick="setUnits(true)">Metric (m)</button>
+    </div>
   </div>
 
   <p id="elevationLabel">Enter the local site elevation (feet):</p>

--- a/o2_percentage_to_altitude.html
+++ b/o2_percentage_to_altitude.html
@@ -8,40 +8,54 @@
       margin: 20px 0;
       text-align: center;
     }
-    .toggle-switch {
-      background: #ddd;
+    .toggle-group {
+      display: inline-flex;
+      border: 2px solid #ddd;
+      border-radius: 6px;
+      overflow: hidden;
+    }
+    .toggle-button {
+      background: #f8f8f8;
       border: none;
-      border-radius: 20px;
       padding: 10px 20px;
       cursor: pointer;
       font-size: 14px;
-      transition: background-color 0.3s;
+      font-weight: 500;
+      transition: all 0.2s;
+      border-right: 1px solid #ddd;
     }
-    .toggle-switch.active {
+    .toggle-button:last-child {
+      border-right: none;
+    }
+    .toggle-button.active {
       background: #007acc;
       color: white;
+    }
+    .toggle-button:hover:not(.active) {
+      background: #e8e8e8;
     }
   </style>
   <script>
     let isMetric = false;
 
-    function toggleUnits() {
-      isMetric = !isMetric;
+    function setUnits(metric) {
+      isMetric = metric;
       localStorage.setItem('unitPreference', isMetric ? 'metric' : 'imperial');
       updateUI();
     }
 
     function updateUI() {
-      const toggle = document.getElementById('unitToggle');
+      const imperialBtn = document.getElementById('imperialBtn');
+      const metricBtn = document.getElementById('metricBtn');
       const resultLabel = document.getElementById('resultLabel');
       
       if (isMetric) {
-        toggle.textContent = 'Metric (m)';
-        toggle.classList.add('active');
+        imperialBtn.classList.remove('active');
+        metricBtn.classList.add('active');
         resultLabel.textContent = 'Equivalent Altitude (in meters): ';
       } else {
-        toggle.textContent = 'Imperial (ft)';
-        toggle.classList.remove('active');
+        imperialBtn.classList.add('active');
+        metricBtn.classList.remove('active');
         resultLabel.textContent = 'Equivalent Altitude (in feet): ';
       }
     }
@@ -86,7 +100,10 @@
   <h1>Oxygen Percentage to Altitude Calculator</h1>
   
   <div class="unit-toggle">
-    <button id="unitToggle" class="toggle-switch" onclick="toggleUnits()">Imperial (ft)</button>
+    <div class="toggle-group">
+      <button id="imperialBtn" class="toggle-button active" onclick="setUnits(false)">Imperial (ft)</button>
+      <button id="metricBtn" class="toggle-button" onclick="setUnits(true)">Metric (m)</button>
+    </div>
   </div>
   
   <p>Enter the effective oxygen percentage (0 to 20.9%):</p>


### PR DESCRIPTION
Resolves #2 

### Problem

The calculators only accept input elevations in imperial (feet) and do not accept metric (meters).

### Solution

Enable toggling between input in imperial or metric.

### 🎩  Screenshot

<img width="400" height="353" alt="image" src="https://github.com/user-attachments/assets/6e3f157e-1da8-432d-8c06-6e8802a7a5da" />
