### PR TITLE
Deprecate calculators without input for ambient elevation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,11 @@ Plan training at altitude or simulate altitude conditions:
 
 | Calculator | Description |
 |------------|-------------|
-| [Altitude to Oxygen Percentage](https://dbeatty10.github.io/altitude-calculator/altitude_to_o2_percentage.html) | Converts altitude in feet to effective oxygen percentage using atmospheric pressure calculations. |
-| [Oxygen Percentage to Altitude](https://dbeatty10.github.io/altitude-calculator/o2_percentage_to_altitude.html) | Converts effective oxygen percentage to equivalent altitude in feet. |
-| [Altitude-O₂ Equivalency Calculator](https://dbeatty10.github.io/altitude-calculator/altitude_o2_to_altitude.html) | Calculate equivalent altitude for 20.9% air based on measured altitude and oxygen percentage of gas mixture. |
-| [Elevation & Equivalent Altitude to O₂ Calculator](https://dbeatty10.github.io/altitude-calculator/elevation_equiv_to_o2.html) | Calculate required oxygen percentage to simulate a target altitude at your local elevation. Useful for Venturi entrainment mask jet percentage calculations. |
+| [Oxygen % to Elevation Calculator](https://dbeatty10.github.io/altitude-calculator/altitude_o2_to_altitude.html) | Calculate equivalent altitude for 20.9% air based on measured altitude and oxygen percentage of gas mixture. |
+| [Elevation to Equivalent Oxygen % Calculator](https://dbeatty10.github.io/altitude-calculator/elevation_equiv_to_o2.html) | Calculate required oxygen percentage based on local elevation and desired equivalent altitude. Useful for hypoxic tents ("live high") or Venturi entrainment mask jet percentage calculations ("train low"). |
 
 ## How to Use
 
 1. **Click a link above** to access the appropriate calculator.
-2. **Enter your data** (altitude in feet or oxygen percentage).
+2. **Enter your data**.
 3. **Get instant results**—no downloads or setup required!

--- a/altitude_to_o2_percentage.html
+++ b/altitude_to_o2_percentage.html
@@ -2,123 +2,74 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Altitude to Oxygen Percentage Calculator</title>
+  <title>Altitude to Oxygen Percentage Calculator - Deprecated</title>
   <style>
-    .unit-toggle {
-      margin: 20px 0;
+    body {
+      font-family: Arial, sans-serif;
+      margin: 40px;
+      line-height: 1.6;
+      max-width: 600px;
+      margin: 40px auto;
       text-align: center;
     }
-    .toggle-group {
-      display: inline-flex;
-      border: 2px solid #ddd;
-      border-radius: 6px;
-      overflow: hidden;
+    .deprecation-notice {
+      background: #fff3cd;
+      border: 1px solid #ffeaa7;
+      border-radius: 8px;
+      padding: 30px;
+      margin: 30px 0;
     }
-    .toggle-button {
-      background: #f8f8f8;
-      border: none;
-      padding: 10px 20px;
-      cursor: pointer;
-      font-size: 14px;
-      font-weight: 500;
-      transition: all 0.2s;
-      border-right: 1px solid #ddd;
+    .deprecation-title {
+      color: #856404;
+      font-size: 1.5em;
+      font-weight: bold;
+      margin-bottom: 15px;
     }
-    .toggle-button:last-child {
-      border-right: none;
+    .deprecation-text {
+      color: #856404;
+      margin-bottom: 25px;
     }
-    .toggle-button.active {
+    .redirect-button {
       background: #007acc;
       color: white;
+      padding: 15px 30px;
+      border: none;
+      border-radius: 6px;
+      font-size: 16px;
+      font-weight: 500;
+      text-decoration: none;
+      display: inline-block;
+      transition: background-color 0.3s;
     }
-    .toggle-button:hover:not(.active) {
-      background: #e8e8e8;
+    .redirect-button:hover {
+      background: #0056a3;
+    }
+    .back-link {
+      margin-top: 30px;
+    }
+    .back-link a {
+      color: #007acc;
+      text-decoration: none;
     }
   </style>
-  <script>
-    let isMetric = false;
-
-    function setUnits(metric) {
-      isMetric = metric;
-      localStorage.setItem('unitPreference', isMetric ? 'metric' : 'imperial');
-      updateUI();
-    }
-
-    function updateUI() {
-      const imperialBtn = document.getElementById('imperialBtn');
-      const metricBtn = document.getElementById('metricBtn');
-      const label = document.getElementById('inputLabel');
-      const input = document.getElementById('altitude');
-      
-      if (isMetric) {
-        imperialBtn.classList.remove('active');
-        metricBtn.classList.add('active');
-        label.textContent = 'Enter the altitude in meters:';
-        input.placeholder = 'Altitude in meters';
-      } else {
-        imperialBtn.classList.add('active');
-        metricBtn.classList.remove('active');
-        label.textContent = 'Enter the altitude in feet:';
-        input.placeholder = 'Altitude in feet';
-      }
-    }
-
-    function convertAltitude() {
-      let altitude = parseFloat(document.getElementById("altitude").value);
-      
-      if (isNaN(altitude) || altitude < 0) {
-        alert("Please enter a valid altitude.");
-        return;
-      }
-      
-      // Convert to feet if metric input
-      if (isMetric) {
-        altitude = altitude * 3.28084; // meters to feet
-        if (altitude > 145442) {
-          alert("Please enter a valid altitude (maximum ~44,300 meters).");
-          return;
-        }
-      } else {
-        if (altitude > 145442) {
-          alert("Please enter a valid altitude between 0 and 145,442 feet.");
-          return;
-        }
-      }
-      
-      // Calculate the effective oxygen percentage using the formula:
-      // f = 20.9 * (1 - (h/145442))^5.2559
-      var oxygenPercentage = 20.9 * Math.pow(1 - (altitude / 145442), 5.2559);
-      
-      // Round the result to one decimal place.
-      oxygenPercentage = Math.round(oxygenPercentage * 10) / 10;
-      
-      // Display the result.
-      document.getElementById("result").innerText = oxygenPercentage + "%";
-    }
-
-    window.onload = function() {
-      // Load saved preference
-      const saved = localStorage.getItem('unitPreference');
-      if (saved === 'metric') {
-        isMetric = true;
-      }
-      updateUI();
-    }
-  </script>
 </head>
 <body>
   <h1>Altitude to Oxygen Percentage Calculator</h1>
   
-  <div class="unit-toggle">
-    <div class="toggle-group">
-      <button id="imperialBtn" class="toggle-button active" onclick="setUnits(false)">Imperial (ft)</button>
-      <button id="metricBtn" class="toggle-button" onclick="setUnits(true)">Metric (m)</button>
+  <div class="deprecation-notice">
+    <div class="deprecation-title">⚠️ This Calculator Has Been Deprecated</div>
+    <div class="deprecation-text">
+      This calculator has been replaced with a more comprehensive version that accounts for local elevation effects on oxygen availability.
+      <br><br>
+      <strong>Please use the new calculator which provides more accurate results by considering your local site elevation.</strong>
     </div>
+    <a href="elevation_equiv_to_o2.html" class="redirect-button">
+      Go to New Calculator →
+    </a>
   </div>
   
-  <p id="inputLabel">Enter the altitude in feet:</p>
-  <input type="number" id="altitude" placeholder="Altitude in feet" onkeypress="if(event.key==='Enter') convertAltitude()">
-  <button onclick="convertAltitude()">Convert</button>
-  <p>Effective Oxygen Percentage: <span id="result"></span></p>
+  <div class="back-link">
+    <a href="index.html">← Back to Calculator Suite</a>
+  </div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -45,32 +45,19 @@
   <h1>Altitude Calculator Suite</h1>
   <p>This suite of web-based calculators helps you convert between altitude and oxygen percentage. Choose a tool below:</p>
   
+  <h2>Recommended Calculators</h2>
   <ul>
     <li>
-      <a href="altitude_to_o2_percentage.html">Altitude to Oxygen Percentage Calculator</a>
-      <div class="description">
-        Convert altitude in feet to effective oxygen percentage using atmospheric pressure calculations.
-      </div>
-    </li>
-    
-    <li>
-      <a href="o2_percentage_to_altitude.html">Oxygen Percentage to Altitude Calculator</a>
-      <div class="description">
-        Convert effective oxygen percentage to equivalent altitude in feet.
-      </div>
-    </li>
-    
-    <li>
-      <a href="altitude_o2_to_altitude.html">Altitude-O₂ Equivalency Calculator</a>
+      <a href="altitude_o2_to_altitude.html">Oxygen % to Elevation Calculator</a>
       <div class="description">
         Calculate equivalent altitude for 20.9% air based on measured altitude and oxygen percentage of gas mixture.
       </div>
     </li>
     
     <li>
-      <a href="elevation_equiv_to_o2.html">Elevation & Equivalent Altitude to O₂ Calculator</a>
+      <a href="elevation_equiv_to_o2.html">Elevation to Equivalent Oxygen % Calculator</a>
       <div class="description">
-        Calculate required oxygen percentage based on local elevation and desired equivalent altitude.
+        Calculate required oxygen percentage based on local elevation and desired equivalent altitude. Useful for hypoxic tents ("live high") or Venturi entrainment mask jet percentage calculations ("train low").
       </div>
     </li>
   </ul>

--- a/o2_percentage_to_altitude.html
+++ b/o2_percentage_to_altitude.html
@@ -2,113 +2,74 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Oxygen Percentage to Altitude Calculator</title>
+  <title>Oxygen Percentage to Altitude Calculator - Deprecated</title>
   <style>
-    .unit-toggle {
-      margin: 20px 0;
+    body {
+      font-family: Arial, sans-serif;
+      margin: 40px;
+      line-height: 1.6;
+      max-width: 600px;
+      margin: 40px auto;
       text-align: center;
     }
-    .toggle-group {
-      display: inline-flex;
-      border: 2px solid #ddd;
-      border-radius: 6px;
-      overflow: hidden;
+    .deprecation-notice {
+      background: #fff3cd;
+      border: 1px solid #ffeaa7;
+      border-radius: 8px;
+      padding: 30px;
+      margin: 30px 0;
     }
-    .toggle-button {
-      background: #f8f8f8;
-      border: none;
-      padding: 10px 20px;
-      cursor: pointer;
-      font-size: 14px;
-      font-weight: 500;
-      transition: all 0.2s;
-      border-right: 1px solid #ddd;
+    .deprecation-title {
+      color: #856404;
+      font-size: 1.5em;
+      font-weight: bold;
+      margin-bottom: 15px;
     }
-    .toggle-button:last-child {
-      border-right: none;
+    .deprecation-text {
+      color: #856404;
+      margin-bottom: 25px;
     }
-    .toggle-button.active {
+    .redirect-button {
       background: #007acc;
       color: white;
+      padding: 15px 30px;
+      border: none;
+      border-radius: 6px;
+      font-size: 16px;
+      font-weight: 500;
+      text-decoration: none;
+      display: inline-block;
+      transition: background-color 0.3s;
     }
-    .toggle-button:hover:not(.active) {
-      background: #e8e8e8;
+    .redirect-button:hover {
+      background: #0056a3;
+    }
+    .back-link {
+      margin-top: 30px;
+    }
+    .back-link a {
+      color: #007acc;
+      text-decoration: none;
     }
   </style>
-  <script>
-    let isMetric = false;
-
-    function setUnits(metric) {
-      isMetric = metric;
-      localStorage.setItem('unitPreference', isMetric ? 'metric' : 'imperial');
-      updateUI();
-    }
-
-    function updateUI() {
-      const imperialBtn = document.getElementById('imperialBtn');
-      const metricBtn = document.getElementById('metricBtn');
-      const resultLabel = document.getElementById('resultLabel');
-      
-      if (isMetric) {
-        imperialBtn.classList.remove('active');
-        metricBtn.classList.add('active');
-        resultLabel.textContent = 'Equivalent Altitude (in meters): ';
-      } else {
-        imperialBtn.classList.add('active');
-        metricBtn.classList.remove('active');
-        resultLabel.textContent = 'Equivalent Altitude (in feet): ';
-      }
-    }
-
-    function convertOxygen() {
-      // Get the oxygen percentage from the input and convert it to a number.
-      var oxygen = parseFloat(document.getElementById("oxygen").value);
-      
-      // Validate the input: oxygen percentage must be between 0 and 20.9.
-      if (isNaN(oxygen) || oxygen < 0 || oxygen > 20.9) {
-        alert("Please enter a valid oxygen percentage between 0 and 20.9.");
-        return;
-      }
-      
-      // Calculate the altitude using the formula:
-      // h = 145442 * [1 - (oxygen/20.9)^(1/5.2559)]
-      var altitude = 145442 * (1 - Math.pow(oxygen / 20.9, 1 / 5.2559));
-      
-      // Convert to meters if metric is selected
-      if (isMetric) {
-        altitude = altitude / 3.28084; // feet to meters
-        altitude = Math.round(altitude / 50) * 50; // nearest 50 meters
-      } else {
-        altitude = Math.round(altitude / 100) * 100; // nearest 100 feet
-      }
-      
-      // Display the result.
-      document.getElementById("result").innerText = altitude.toLocaleString();
-    }
-
-    window.onload = function() {
-      // Load saved preference
-      const saved = localStorage.getItem('unitPreference');
-      if (saved === 'metric') {
-        isMetric = true;
-      }
-      updateUI();
-    }
-  </script>
 </head>
 <body>
   <h1>Oxygen Percentage to Altitude Calculator</h1>
   
-  <div class="unit-toggle">
-    <div class="toggle-group">
-      <button id="imperialBtn" class="toggle-button active" onclick="setUnits(false)">Imperial (ft)</button>
-      <button id="metricBtn" class="toggle-button" onclick="setUnits(true)">Metric (m)</button>
+  <div class="deprecation-notice">
+    <div class="deprecation-title">⚠️ This Calculator Has Been Deprecated</div>
+    <div class="deprecation-text">
+      This calculator has been replaced with a more comprehensive version that accounts for local elevation and gas mixture effects.
+      <br><br>
+      <strong>Please use the new calculator which provides more accurate results by considering your local site elevation and oxygen mixture.</strong>
     </div>
+    <a href="altitude_o2_to_altitude.html" class="redirect-button">
+      Go to New Calculator →
+    </a>
   </div>
   
-  <p>Enter the effective oxygen percentage (0 to 20.9%):</p>
-  <input type="number" id="oxygen" step="0.1" placeholder="Oxygen percentage" onkeypress="if(event.key==='Enter') convertOxygen()">
-  <button onclick="convertOxygen()">Convert</button>
-  <p id="resultLabel">Equivalent Altitude (in feet): <span id="result"></span></p>
+  <div class="back-link">
+    <a href="index.html">← Back to Calculator Suite</a>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
Resolves #5

### Problem

Two of the calculators do not have input for the ambient elevation (which affects the estimated barometric pressure), so they are implicitly fixed at sea-level.

### Solution

Deprecate these calculators remove any links to them in `index.html` or the `README`.
Provide hyperlinks to the calculators that do require explicit input for ambient elevation (which allows for expressing a wide range of altitudes).